### PR TITLE
Sanitize Docker tags

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -13,6 +13,7 @@ jobs:
     permissions:
       contents: read
       id-token: write
+      packages: write
     steps:
       - uses: actions/checkout@v4
       - uses: docker/setup-buildx-action@v3
@@ -28,6 +29,7 @@ jobs:
           tags: type=raw,value=latest
       - uses: docker/build-push-action@v6
         with:
+          context: .
           push: true
           tags: ${{ steps.docker-meta.outputs.tags }}
           labels: ${{ steps.docker-meta.outputs.labels }}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -21,8 +21,13 @@ jobs:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
+      - uses: docker/metadata-action@v5
+        id: docker-meta
+        with:
+          images: ghcr.io/${{ github.repository }}
+          tags: type=raw,value=latest
       - uses: docker/build-push-action@v6
         with:
           push: true
-          tags: |
-            ghcr.io/${{ github.repository }}:latest
+          tags: ${{ steps.docker-meta.outputs.tags }}
+          labels: ${{ steps.docker-meta.outputs.labels }}


### PR DESCRIPTION
This uses `docker/metadata-action` to sanitize the Docker tag names, in this case relevant for upper/lowercase names. This was a suggestion from https://github.com/docker/build-push-action/issues/237#issuecomment-848673650

The second commit correctly sets the docker build context, which stops buildx from doing its own checkout - and it allows GHA to write to the repo in case it can't by default.