### PR TITLE
Some UI+UX polish

### DIFF
--- a/server/frontend/src/components/Buckets/ReportPreviewRow.vue
+++ b/server/frontend/src/components/Buckets/ReportPreviewRow.vue
@@ -47,21 +47,24 @@
       ({{ report.app_channel }})
     </td>
     <td>
-      {{
-        report.details.boolean
-          .broken_site_report_tab_info_antitracking_has_tracking_content_blocked
-      }}
-    </td>
-    <td>
-      {{
-        report.details.string
-          .broken_site_report_tab_info_antitracking_block_list
-      }}
-    </td>
-    <td>
+      PBM:
       {{
         report.details.boolean
           .broken_site_report_tab_info_antitracking_is_private_browsing
+          | humanBool
+      }}<br />
+
+      Blocklist:
+      {{
+        report.details.string
+          .broken_site_report_tab_info_antitracking_block_list || "n/a"
+      }}<br />
+
+      Any content blocked:
+      {{
+        report.details.boolean
+          .broken_site_report_tab_info_antitracking_has_tracking_content_blocked
+          | humanBool
       }}
     </td>
   </tr>
@@ -79,6 +82,13 @@ export default {
   },
   filters: {
     shorterDate: shorterDate,
+    humanBool: (value) => {
+      if (value === undefined || value === null) {
+        return "n/a";
+      }
+
+      return value ? "yes" : "no";
+    },
   },
   methods: {
     staticLogo(name) {

--- a/server/frontend/src/components/Buckets/ReportPreviewRow.vue
+++ b/server/frontend/src/components/Buckets/ReportPreviewRow.vue
@@ -8,7 +8,8 @@
     </td>
     <td class="wrap-normal comments-col">
       <div>
-        {{ maybeTranslatedComments(report) }}
+        <strong>{{ report.breakage_category }}</strong
+        >: {{ maybeTranslatedComments(report) }}
       </div>
     </td>
     <td>
@@ -45,7 +46,6 @@
     <td>{{ report.app_name }}</td>
     <td>{{ report.app_channel }}</td>
     <td>{{ report.app_version }}</td>
-    <td>{{ report.breakage_category }}</td>
     <td>
       {{
         report.details.boolean

--- a/server/frontend/src/components/Buckets/ReportPreviewRow.vue
+++ b/server/frontend/src/components/Buckets/ReportPreviewRow.vue
@@ -42,10 +42,10 @@
         :src="staticLogo('android')"
       />
       <span v-else>{{ report.os }}</span>
+      {{ report.app_name }}
+      {{ report.app_version }}
+      ({{ report.app_channel }})
     </td>
-    <td>{{ report.app_name }}</td>
-    <td>{{ report.app_channel }}</td>
-    <td>{{ report.app_version }}</td>
     <td>
       {{
         report.details.boolean

--- a/server/frontend/src/components/Buckets/ReportPreviewRow.vue
+++ b/server/frontend/src/components/Buckets/ReportPreviewRow.vue
@@ -1,8 +1,10 @@
 <template>
   <tr v-on:click="report.view_url">
     <td class="wrap-normal">{{ report.reported_at | shorterDate }}</td>
-    <td class="wrap-anywhere">
-      <span class="two-line-limit">{{ report.url }}</span>
+    <td class="url-col">
+      <a :href="report.url" target="_blank" rel="noreferrer">
+        {{ report.url }}
+      </a>
     </td>
     <td class="wrap-normal">{{ maybeTranslatedComments(report) }}</td>
     <td>
@@ -96,3 +98,18 @@ export default {
   },
 };
 </script>
+
+<style scoped>
+.url-col a {
+  display: block;
+  max-width: 300px;
+  overflow: scroll;
+  text-overflow: ellipsis;
+
+  /*
+   * This is to ensure the overlay scrollbar isn't overlaying the text. Ideally,
+   * this link would be `height: 100%`, but bug 1598458 is a thing.
+   */
+  padding-bottom: 1.2em;
+}
+</style>

--- a/server/frontend/src/components/Buckets/ReportPreviewRow.vue
+++ b/server/frontend/src/components/Buckets/ReportPreviewRow.vue
@@ -1,6 +1,9 @@
 <template>
   <tr v-on:click="report.view_url">
-    <td class="wrap-normal">{{ report.reported_at | shorterDate }}</td>
+    <td class="wrap-normal">
+      {{ report.reported_at | shorterDate }}<br />
+      (<a :href="report.view_url">Full details</a>)
+    </td>
     <td class="url-col">
       <a :href="report.url" target="_blank" rel="noreferrer">
         {{ report.url }}

--- a/server/frontend/src/components/Buckets/ReportPreviewRow.vue
+++ b/server/frontend/src/components/Buckets/ReportPreviewRow.vue
@@ -6,7 +6,11 @@
         {{ report.url }}
       </a>
     </td>
-    <td class="wrap-normal">{{ maybeTranslatedComments(report) }}</td>
+    <td class="wrap-normal comments-col">
+      <div>
+        {{ maybeTranslatedComments(report) }}
+      </div>
+    </td>
     <td>
       <img
         v-if="report.os === 'Linux'"
@@ -100,6 +104,15 @@ export default {
 </script>
 
 <style scoped>
+.comments-col {
+  overflow-wrap: anywhere;
+
+  div {
+    max-height: 150px;
+    overflow: scroll;
+  }
+}
+
 .url-col a {
   display: block;
   max-width: 300px;

--- a/server/frontend/src/components/Buckets/ReportPreviewRow.vue
+++ b/server/frontend/src/components/Buckets/ReportPreviewRow.vue
@@ -1,6 +1,6 @@
 <template>
   <tr v-on:click="report.view_url">
-    <td class="wrap-normal">{{ report.reported_at | date }}</td>
+    <td class="wrap-normal">{{ report.reported_at | shorterDate }}</td>
     <td class="wrap-anywhere">
       <span class="two-line-limit">{{ report.url }}</span>
     </td>
@@ -62,7 +62,7 @@
 </template>
 
 <script>
-import { date } from "../../helpers";
+import { shorterDate } from "../../helpers";
 
 export default {
   props: {
@@ -72,7 +72,7 @@ export default {
     },
   },
   filters: {
-    date: date,
+    shorterDate: shorterDate,
   },
   methods: {
     staticLogo(name) {

--- a/server/frontend/src/components/Buckets/View.vue
+++ b/server/frontend/src/components/Buckets/View.vue
@@ -90,81 +90,10 @@
                 :data="bucket.report_history"
                 :range="activityRange"
               />
-              <div class="btn-group">
-                <a :href="reportsUrl" class="btn btn-default">View Reports</a>
-                <a
-                  title="Add/Update"
-                  class="btn btn-danger"
-                  v-on:click="submitWatchForm"
-                  >Notify on New Reports</a
-                >
-              </div>
-              <form :action="watchUrl" ref="bucketWatchForm" method="post">
-                <input type="hidden" name="bucket" :value="bucket.id" />
-                <input
-                  type="hidden"
-                  name="report"
-                  :value="bucket.latest_entry_id"
-                />
-              </form>
-            </td>
-          </tr>
-          <tr>
-            <td>Latest Report</td>
-            <td>{{ bucket.latest_report | date }}</td>
-          </tr>
-          <tr>
-            <td>Priority</td>
-            <td>{{ bucket.priority }}</td>
-          </tr>
-          <tr>
-            <td>Signature</td>
-            <td>
-              <div id="signature" class="collapse">
-                <pre><code>{{ prettySignature }}</code></pre>
-              </div>
-              <button
-                aria-controls="signature"
-                aria-expanded="false"
-                class="btn btn-default btn-xs"
-                data-target="#signature"
-                data-toggle="collapse"
-              >
-                <span
-                  aria-label="Show signature field"
-                  class="bi bi-eye-fill"
-                  title="Show signature field"
-                ></span>
-                <span
-                  aria-label="Hide signature field"
-                  class="bi bi-eye-slash-fill"
-                  title="Hide signature field"
-                ></span>
-              </button>
             </td>
           </tr>
         </tbody>
       </table>
-
-      <div v-if="canEdit" class="btn-group">
-        <a
-          aria-label="Edit bucket"
-          class="btn btn-default"
-          :href="editUrl"
-          title="Edit bucket"
-          >Edit</a
-        >
-        <a
-          aria-label="Delete bucket"
-          class="btn btn-danger"
-          :href="delUrl"
-          title="Delete bucket"
-          >Delete</a
-        >
-        <br />
-        <br />
-      </div>
-
       <div class="table-responsive">
         <table
           class="table table-condensed table-hover table-bordered table-db wrap-none"
@@ -317,10 +246,7 @@ export default {
       required: true,
     },
   },
-  mounted() {
-    const el = document.getElementsByName("csrfmiddlewaretoken")[0];
-    this.$refs.bucketWatchForm.appendChild(el);
-  },
+  mounted() {},
   methods: {
     buildQueryParams() {
       const result = {

--- a/server/frontend/src/components/Buckets/View.vue
+++ b/server/frontend/src/components/Buckets/View.vue
@@ -107,7 +107,6 @@
               <th>App</th>
               <th>Channel</th>
               <th>Version</th>
-              <th>Breakage Category</th>
               <th>ETP content blocked?</th>
               <th>ETP blocklist</th>
               <th>Is PBM?</th>

--- a/server/frontend/src/components/Buckets/View.vue
+++ b/server/frontend/src/components/Buckets/View.vue
@@ -103,10 +103,7 @@
               <th>Date Reported</th>
               <th>URL</th>
               <th>User Comments</th>
-              <th>OS</th>
-              <th>App</th>
-              <th>Channel</th>
-              <th>Version</th>
+              <th>Product</th>
               <th>ETP content blocked?</th>
               <th>ETP blocklist</th>
               <th>Is PBM?</th>

--- a/server/frontend/src/components/Buckets/View.vue
+++ b/server/frontend/src/components/Buckets/View.vue
@@ -104,9 +104,7 @@
               <th>URL</th>
               <th>User Comments</th>
               <th>Product</th>
-              <th>ETP content blocked?</th>
-              <th>ETP blocklist</th>
-              <th>Is PBM?</th>
+              <th>ETP &amp; PBM</th>
             </tr>
           </thead>
           <tbody>

--- a/server/frontend/src/helpers.js
+++ b/server/frontend/src/helpers.js
@@ -52,6 +52,12 @@ export const date = (datetime) => {
   return new Date(datetime).toUTCString();
 };
 
+export const shorterDate = (datetime) => {
+  const [date, time] = new Date(datetime).toISOString().split("T");
+  const hhmm = time.split(":").slice(0, 2).join(":");
+  return `${date} ${hhmm}`;
+};
+
 export const assignExternalBug = (bucketId, bugId, providerId) => {
   const payload = {
     bug: bugId,


### PR DESCRIPTION
A series of individual commits, best reviewed individually. I removed a bunch of features that we're not going to use. I made sure that too long URLs and comments are handled nicely without filling your entire screen with text. Also, I collapsed a few columns together to use the space a bit more efficiently.

IMHO, this makes the whole view more information-dense, but also a bit less overwhelming. [Before](https://github.com/user-attachments/assets/4691a410-52b8-4434-ac2d-0b7e5577c086), [after](https://github.com/user-attachments/assets/1388b6b4-3ad5-435e-ad3e-b1e52165b55c).

r? @jgraham 