### PR TITLE
Known bug links: Search all `site-report`s, not just things in the WebCompat component.

### DIFF
--- a/server/frontend/src/components/Buckets/View.vue
+++ b/server/frontend/src/components/Buckets/View.vue
@@ -367,6 +367,11 @@ export default {
         ["f7", "component"],
         ["v7", "Privacy: Site Reports"],
         ["f8", "CP"],
+        ["f9", "OP"],
+        ["o10", "substring"],
+        ["f10", "keywords"],
+        ["v10", "webcompat:site-report"],
+        ["f11", "CP"],
       ]);
 
       const url = new URL("https://bugzilla.mozilla.org/buglist.cgi");


### PR DESCRIPTION
This resolves #36, but instead of adding a second link, I figured it's best to just search the entirety of Bugzilla for `webcompat:site-report` marked bugs, as opposed to limiting it to specific components. We encourage engineers to move bugs into their own components as long as they have the site-report keyword, and this matches what we'd display with a bug-list inline.

r? @jgraham 