### PR TITLE
Skip importing reports without a breakage_category set

### DIFF
--- a/server/frontend/src/components/Buckets/ReportPreviewRow.vue
+++ b/server/frontend/src/components/Buckets/ReportPreviewRow.vue
@@ -11,7 +11,7 @@
     </td>
     <td class="wrap-normal comments-col">
       <div>
-        <strong>{{ report.breakage_category }}</strong
+        <strong>{{ report.breakage_category ?? "unknown" }}</strong
         >: {{ maybeTranslatedComments(report) }}
       </div>
     </td>

--- a/server/reportmanager/serializers.py
+++ b/server/reportmanager/serializers.py
@@ -185,7 +185,9 @@ class ReportEntrySerializer(serializers.ModelSerializer):
     app_name = serializers.CharField(source="app.name")
     app_channel = serializers.CharField(source="app.channel")
     app_version = serializers.CharField(source="app.version")
-    breakage_category = serializers.CharField(source="breakage_category.value")
+    breakage_category = serializers.CharField(
+        source="breakage_category.value", allow_null=True
+    )
     os = serializers.CharField(source="os.name", max_length=63)
 
     class Meta:


### PR DESCRIPTION
This technically shouldn't happen, but we have a small number of bugs that don't have one set. I also added a sanity-check for non-null URLs, and moved the no-comment check into the query, because not even querying those makes more sense than skipping them during import.

r? @jgraham 