### PR TITLE
Bump linting to Python 3.10, drop 3.9

### DIFF
--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -31,10 +31,6 @@ tasks:
         - tox
       jobs:
         include:
-          - name: tests python 3.9 django 4.x
-            version: "3.9"
-            env:
-              TOXENV: py39
           - name: tests python 3.10 django 4.x
             version: "3.10"
             env:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "WebCompatManager"
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 authors = [
     {name = "Christian Holler", email = "choller@mozilla.com"},
     {name = "Jesse Schwartzentruber", email = "jschwartzentruber@mozilla.com"},
@@ -92,7 +92,7 @@ norecursedirs = [
 
 [tool.ruff]
 fix = true
-target-version = "py39"
+target-version = "py310"
 extend-exclude = ["**/migrations/*.py"]
 
 [tool.ruff.lint]

--- a/server/reportmanager/forms.py
+++ b/server/reportmanager/forms.py
@@ -217,7 +217,7 @@ class UserSettingsForm(ModelForm):
             )
         )
 
-        instance = kwargs.get("instance", None)
+        instance = kwargs.get("instance")
         if instance:
             self.initial["email"] = instance.user.email
 

--- a/server/reportmanager/views.py
+++ b/server/reportmanager/views.py
@@ -1094,7 +1094,7 @@ def json_to_query(json_str):
         raise RuntimeError(f"Invalid JSON: {e}")
 
     def get_query_obj(obj, key=None):
-        if obj is None or isinstance(obj, (str, list, int)):
+        if obj is None or isinstance(obj, str | list | int):
             kwargs = {key: obj}
             qobj = Q(**kwargs)
             return qobj

--- a/server/server/views.py
+++ b/server/server/views.py
@@ -88,7 +88,7 @@ def json_to_query(json_str):
         raise RuntimeError(f"Invalid JSON: {e}")
 
     def get_query_obj(obj, key=None):
-        if obj is None or isinstance(obj, (str, list, int)):
+        if obj is None or isinstance(obj, str | list | int):
             kwargs = {key: obj}
             qobj = Q(**kwargs)
             return qobj

--- a/src/webcompat/symptoms.py
+++ b/src/webcompat/symptoms.py
@@ -240,5 +240,5 @@ class DetailsSymptom(Symptom):
         return any(
             self.matcher.matches(value.value)
             for value in self.path.find(report.details)
-            if value.value is None or isinstance(value.value, (bool, float, int, str))
+            if value.value is None or isinstance(value.value, bool | float | int | str)
         )

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{39,310,311,312}
+envlist = py{310,311,312}
 minversion = 3.2
 tox_pip_extensions_ext_venv_update = true
 skip_missing_interpreters = true
@@ -31,7 +31,7 @@ deps =
 
 [testenv:update-reqs]
 skip_install = true
-basepython = python3.9
+basepython = python3.10
 deps =
     pip-tools
 install_command = python -m pip install {opts} {packages}


### PR DESCRIPTION
We [already use 3.10 inside the Docker container](https://github.com/MozillaSecurity/WebCompatManager/blob/05cc025d640f315f276310332eb9b84cd0533b6d/Dockerfile#L23) so we know it works. Linting based on the version we actually run probably makes sense, we don't need compatibility with older versions.

While we should eventually update to newer versions, I noticed this while working on the ML classification import, where I wanted to use a `match` statement, but since that wasn't available in 3.9, ruff was unhappy with me.

Code changes in this PR are to confirm what ruff wants for 3.10.

r? @jgraham 