### PR TITLE
Use json.dumps instead of a naive format string to generate the report signature

### DIFF
--- a/src/webcompat/models.py
+++ b/src/webcompat/models.py
@@ -68,17 +68,13 @@ class Report:
     def create_signature(self) -> Signature:
         """Create a default signature"""
         return Signature(
-            f"""
-            {{
-              "symptoms": [
-                {{
-                  "type": "url",
-                  "part": "hostname",
-                  "value": "{self.url.hostname}"
-                }}
-              ]
-            }}
-            """
+            json.dumps(
+                {
+                    "symptoms": [
+                        {"type": "url", "part": "hostname", "value": self.url.hostname}
+                    ]
+                }
+            )
         )
 
 


### PR DESCRIPTION
Report `uuid=c2170bc4-d23b-4495-9083-3c5b18ddd8ae` is why.

r? @jgraham 