### PR TITLE
Add a report breakdown for the buckets view

### DIFF
--- a/server/frontend/src/components/Buckets/View.vue
+++ b/server/frontend/src/components/Buckets/View.vue
@@ -73,7 +73,7 @@
             </td>
           </tr>
           <tr>
-            <td>Reports in this bucket</td>
+            <td>Total Reports</td>
             <td>
               {{ bucket.size }}
               <span
@@ -87,6 +87,76 @@
                 :data="bucket.report_history"
                 :range="activityRange"
               />
+            </td>
+          </tr>
+          <tr>
+            <td>Report Breakdown</td>
+            <td>
+              <div></div>
+              <table class="table">
+                <thead>
+                  <tr>
+                    <th>Platform</th>
+                    <th>%</th>
+                    <th>OS</th>
+                    <th>Browser</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  <template
+                    v-for="platform in ['desktop', 'mobile']"
+                    :key="platform"
+                  >
+                    <tr v-if="parsedSummary[platform].total > 0">
+                      <td>
+                        {{ platform == "desktop" ? "Desktop" : "Mobile" }}
+                      </td>
+                      <td>{{ parsedSummary[platform].pct }}%</td>
+                      <td>
+                        <ul class="summary-list">
+                          <li
+                            v-for="item in parsedSummary[platform].os"
+                            :key="item.name"
+                          >
+                            <img
+                              v-if="osLogoKey(item.name)"
+                              width="16px"
+                              height="16px"
+                              :alt="item.name"
+                              :src="staticLogo(osLogoKey(item.name))"
+                            />
+                            <span v-else>{{ item.name }}</span>
+                            {{ item.pct }}%
+                          </li>
+                        </ul>
+                      </td>
+                      <td>
+                        <ul class="summary-list">
+                          <li
+                            v-for="item in parsedSummary[platform]
+                              .browserVersions"
+                            :key="item.name"
+                          >
+                            {{ item.name }}: {{ item.pct }}%
+                          </li>
+                        </ul>
+                      </td>
+                    </tr>
+                  </template>
+                </tbody>
+              </table>
+              <table class="table">
+                <tbody>
+                  <tr>
+                    <th>PBM enabled</th>
+                    <td>{{ parsedSummary.pbmEnabled }}%</td>
+                  </tr>
+                  <tr>
+                    <th>Content blocked</th>
+                    <td>{{ parsedSummary.contentBlocked }}%</td>
+                  </tr>
+                </tbody>
+              </table>
             </td>
           </tr>
           <tr>
@@ -239,6 +309,49 @@ export default {
     prettySignature() {
       return jsonPretty(this.bucket.signature);
     },
+    parsedSummary() {
+      const s = this.bucket.summary;
+      if (!s || s.total === 0) {
+        return null;
+      }
+
+      const formatPercent = (n, total) =>
+        total > 0 ? ((n / total) * 100).toFixed(1) : "0.0";
+
+      const knownOS = ["Windows", "Mac", "Linux", "Android"];
+
+      const parsePlatform = (platform) => {
+        const { total, os, browser_versions } = platform;
+        const osList = [
+          ...knownOS
+            .filter((name) => os[name] !== undefined)
+            .map((name) => ({ name, pct: formatPercent(os[name], total) })),
+          ...Object.entries(os)
+            .filter(([name]) => !knownOS.includes(name))
+            .map(([name, count]) => ({
+              name,
+              pct: formatPercent(count, total),
+            })),
+        ];
+        const browserVersions = Object.entries(browser_versions)
+          .sort((a, b) => b[0] - a[0])
+          .sort((a, b) => b[1] - a[1])
+          .map(([name, count]) => ({ name, pct: formatPercent(count, total) }));
+        return {
+          total,
+          pct: formatPercent(total, s.total),
+          os: osList,
+          browserVersions,
+        };
+      };
+
+      return {
+        desktop: parsePlatform(s.desktop),
+        mobile: parsePlatform(s.mobile),
+        pbmEnabled: formatPercent(s.pbm_enabled, s.total),
+        contentBlocked: formatPercent(s.content_blocked, s.total),
+      };
+    },
   },
   created: function () {
     if (this.$route.hash.startsWith("#")) {
@@ -256,6 +369,19 @@ export default {
   mounted() {},
   methods: {
     formatDate: date,
+    staticLogo(name) {
+      return window.location.origin + "/static/img/os/" + name + ".png";
+    },
+    osLogoKey(name) {
+      return (
+        {
+          Linux: "linux",
+          Mac: "macosx",
+          Windows: "windows",
+          Android: "android",
+        }[name] ?? null
+      );
+    },
     buildQueryParams() {
       const result = {
         query: JSON.stringify({
@@ -443,5 +569,10 @@ button[aria-expanded="false"] .bi-eye-slash-fill {
 .ml-threshold-value {
   font-weight: bold;
   min-width: 60px;
+}
+.summary-list {
+  list-style: none;
+  padding: 0;
+  margin: 0.25em 0 0;
 }
 </style>

--- a/server/frontend/src/components/Buckets/View.vue
+++ b/server/frontend/src/components/Buckets/View.vue
@@ -89,7 +89,7 @@
               />
             </td>
           </tr>
-          <tr>
+          <tr v-if="parsedSummary">
             <td>Report Breakdown</td>
             <td>
               <div></div>

--- a/server/reportmanager/views.py
+++ b/server/reportmanager/views.py
@@ -996,6 +996,67 @@ class BucketViewSet(
 
             response.data["report_history"] = list(hits.values("begin", "count"))
 
+            reports = ReportEntry.objects.filter(bucket_id=response.data["id"])
+
+            os_counts = {
+                (row["os__name"] or "Unknown"): row["count"]
+                for row in reports.values("os__name").annotate(count=Count("id"))
+            }
+
+            desktop_browser_versions: dict[str, int] = {}
+            mobile_browser_versions: dict[str, int] = {}
+            for row in reports.values("app__name", "app__version", "os__name").annotate(
+                count=Count("id")
+            ):
+                app_name = row["app__name"] or "Unknown"
+                app_version = row["app__version"] or "Unknown"
+                os_name = (row["os__name"] or "Unknown").lower()
+                major = app_version.split(".")[0]
+                key = f"{app_name} {major}"
+                if os_name == "android":
+                    mobile_browser_versions[key] = (
+                        mobile_browser_versions.get(key, 0) + row["count"]
+                    )
+                else:
+                    desktop_browser_versions[key] = (
+                        desktop_browser_versions.get(key, 0) + row["count"]
+                    )
+
+            mobile_os = {k: v for k, v in os_counts.items() if k.lower() == "android"}
+            desktop_os = {k: v for k, v in os_counts.items() if k.lower() != "android"}
+
+            agg = reports.aggregate(
+                total=Count("id"),
+                pbm_count=Count(
+                    "id",
+                    filter=Q(
+                        details__boolean__broken_site_report_tab_info_antitracking_is_private_browsing=True
+                    ),
+                ),
+                blocked_count=Count(
+                    "id",
+                    filter=Q(
+                        details__boolean__broken_site_report_tab_info_antitracking_has_tracking_content_blocked=True
+                    ),
+                ),
+            )
+
+            response.data["summary"] = {
+                "total": agg["total"],
+                "desktop": {
+                    "total": sum(desktop_os.values()),
+                    "os": desktop_os,
+                    "browser_versions": desktop_browser_versions,
+                },
+                "mobile": {
+                    "total": sum(mobile_os.values()),
+                    "os": mobile_os,
+                    "browser_versions": mobile_browser_versions,
+                },
+                "pbm_enabled": agg["pbm_count"],
+                "content_blocked": agg["blocked_count"],
+            }
+
         return response
 
     def __validate(self, bucket, submit_save, reassign, limit, offset, created):


### PR DESCRIPTION
This provides a summary of how many reports come from each platform/OS as well as how many have PBM or ETP blocking.

The goal is to make it easier to see things like buckets being specific to specific platforms.