### PR TITLE
Move playwright install to commands_pre

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,8 +87,5 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@v7
 
-      - name: Install Playwright browsers
-        run: uv run --extra=dev playwright install --with-deps chromium firefox
-
       - name: Run e2e tests
         run: uv run --extra=dev tox -e e2e

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -181,6 +181,7 @@ commands = [["pytest", "-v", "-m", "not ui", "{posargs}"]]
 
 [tool.tox.env.e2e]
 extras = ["dev", "server"]
+commands_pre = [["playwright", "install", "--with-deps", "chromium", "firefox"]]
 commands = [["pytest", "-m", "ui", "--browser", "firefox", "--browser", "chromium", "--no-cov", "{posargs}"]]
 
 [tool.tox.env.mypy]


### PR DESCRIPTION
From [this error](https://github.com/MozillaSecurity/WebCompatManager/actions/runs/25131400814/job/73786227731?pr=192) it looks like running `uv run --extra=dev playwright install --with-deps chromium firefox`, in CI installs browsers matching the playwright version pinned in uv.lock (playwright firefox v1509):
```
Firefox 146.0.1 (playwright firefox v1509) downloaded to /home/runner/.cache/ms-playwright/firefox-1509
```

But tox is installing a newer playwright version, so can't locate the browsers that were just installed:
```
        except Exception as error:
>           raise rewrite_error(error, f"{parsed_st['apiName']}: {error}") from None
E           playwright._impl._errors.Error: BrowserType.launch: Executable doesn't exist at /home/runner/.cache/ms-playwright/firefox-1511/firefox/firefox
```
Moving the browser install to `commands_pre` so it runs inside tox virtualenv seems to help.