### PR TITLE
Fix the issue with domain filter where searching for another domain doesn't clear the previous one

### DIFF
--- a/server/frontend/src/components/Buckets/List.vue
+++ b/server/frontend/src/components/Buckets/List.vue
@@ -228,6 +228,19 @@ import PageNav from "../PageNav.vue";
 import Row from "./Row.vue";
 import HelpJSONQueryPopover from "../HelpJSONQueryPopover.vue";
 
+const domainFilterSignature = {
+  op: "AND",
+  1: {
+    op: "AND",
+    0: {
+      op: "OR",
+      domain: MatchObjects.ANY,
+      domain__endswith: MatchObjects.ANY,
+    },
+    domain__isnull: MatchObjects.ANY,
+  },
+};
+
 export default {
   components: {
     ClipLoader: LoadingSpinner,
@@ -268,18 +281,6 @@ export default {
       "size",
     ];
     const defaultSortKeys = ["-priority_score", "-size", "-latest_report"];
-    const domainFilterSignature = {
-      op: "AND",
-      1: {
-        op: "AND",
-        0: {
-          op: "OR",
-          domain: MatchObjects.ANY,
-          domain__endswith: MatchObjects.ANY,
-        },
-        domain__isnull: MatchObjects.ANY,
-      },
-    };
 
     return {
       advancedQuery: false,
@@ -288,7 +289,6 @@ export default {
       currentPage: 1,
       defaultSortKeys: defaultSortKeys,
       domainFilter: "",
-      domainFilterSignature: domainFilterSignature,
       loading: false,
       modifiedCache: {},
       pageSize: 100,
@@ -352,7 +352,7 @@ export default {
         this.queryStr = JSON.stringify(parsedQuery, null, 2);
         // Extract domain filter if present
         const matcher = new MatchObjects();
-        if (matcher.match(parsedQuery, this.domainFilterSignature)) {
+        if (matcher.match(parsedQuery, domainFilterSignature)) {
           this.domainFilter = parsedQuery[1][0].domain;
         } else if (parsedQuery.domain) {
           this.domainFilter = parsedQuery.domain;
@@ -404,7 +404,7 @@ export default {
       let query = JSON.parse(this.queryStr);
 
       const matcher = new MatchObjects();
-      if (matcher.match(query, this.domainFilterSignature)) {
+      if (matcher.match(query, domainFilterSignature)) {
         query = query[0];
       }
 


### PR DESCRIPTION
I've noticed when I search, for example, for `directv.com` and afterwards for `youtube.com`, the search won't return any results. It seems that resulting query combines the two domains queries with AND:
```
{
  "0": {
    "0": {
      "op": "AND",
      "bug__isnull": true,
      "triage_status__isnull": true
    },
    "1": {
      "0": {
        "op": "OR",
        "domain": "directv.com",
        "domain__endswith": ".directv.com"
      },
      "op": "AND",
      "domain__isnull": false
    },
    "op": "AND"
  },
  "1": {
    "0": {
      "op": "OR",
      "domain": "youtube.com",
      "domain__endswith": ".youtube.com"
    },
    "op": "AND",
    "domain__isnull": false
  },
  "op": "AND"
}
```
I've used Claude to find the root cause and confirmed that it's indeed the case, here is the explanation it produced:

Root cause: domainFilterSignature was stored in Vue's reactive data(). Vue wraps all nested objects in ES6 Proxies, including the MatchObjects.ANY = {} sentinel values. The match() function detects ANY markers with sigValue === MatchObjects.ANY (strict reference equality), but Proxy({}) !== {}, so every ANY check silently failed. This caused the type check for domain string values (typeof "x.com" != typeof Proxy({}) → "string" != "object") to return false, meaning match() always returned false for a domain-filtered query. As a result, the old domain filter was never stripped before wrapping with the new one.

The same bug also prevented the domain input from being populated when opening a shared link in a new tab — the match in created() failed for the same reason, so domainFilter was never set from the URL hash.
