### PR TITLE
Add gdrive scope to be able to access worldcup domains view

### DIFF
--- a/server/reportmanager/management/commands/import_domain_list.py
+++ b/server/reportmanager/management/commands/import_domain_list.py
@@ -59,7 +59,13 @@ class Command(BaseCommand):
         params = {"project": settings.BIGQUERY_PROJECT}
         if svc_acct := getattr(settings, "BIGQUERY_SERVICE_ACCOUNT", None):
             params["credentials"] = (
-                service_account.Credentials.from_service_account_info(svc_acct)
+                service_account.Credentials.from_service_account_info(
+                    svc_acct,
+                    scopes=[
+                        "https://www.googleapis.com/auth/bigquery",
+                        "https://www.googleapis.com/auth/drive",
+                    ],
+                )
             )
 
         client = bigquery.Client(**params)


### PR DESCRIPTION
As the `moz-fx-dev-dschubert-wckb.webcompat_knowledge_base.world_cup_2026_urls` depends on a spreadsheet we need additional scopes