### PR TITLE
Add EXISTS operator

### DIFF
--- a/server/frontend/src/bucket_filter_config.js
+++ b/server/frontend/src/bucket_filter_config.js
@@ -148,10 +148,14 @@ class CountryRankBucketFilter extends BucketFilter {
     }
     const opMap = { "<=": "lte", "<": "lt", ">=": "gte", ">": "gt", "": "lte" };
     const djangoOp = opMap[op] ?? "lte";
+    // Match one country_ranks row on both country and rank. This avoids
+    // Django's multi-valued relation behavior where separate related-field filters
+    // may be satisfied by different rows for the same bucket.
     return {
-      op: "AND",
-      country_ranks__country: this.countryColumn,
-      [`country_ranks__rank__${djangoOp}`]: value,
+      op: "EXISTS",
+      relation: "country_ranks",
+      country: this.countryColumn,
+      [`rank__${djangoOp}`]: value,
     };
   }
 }

--- a/server/frontend/tests/country_rank_filter.test.js
+++ b/server/frontend/tests/country_rank_filter.test.js
@@ -15,45 +15,50 @@ describe("CountryRankBucketFilter", () => {
   test("toQuery with <= produces lte lookup", () => {
     const filter = BUCKET_FILTERS["poland_rank"];
     expect(filter.toQuery(1000, "<=")).toEqual({
-      op: "AND",
-      country_ranks__country: "poland_rank",
-      country_ranks__rank__lte: 1000,
+      op: "EXISTS",
+      relation: "country_ranks",
+      country: "poland_rank",
+      rank__lte: 1000,
     });
   });
 
   test("toQuery with < produces lt lookup", () => {
     const filter = BUCKET_FILTERS["poland_rank"];
     expect(filter.toQuery(1000, "<")).toEqual({
-      op: "AND",
-      country_ranks__country: "poland_rank",
-      country_ranks__rank__lt: 1000,
+      op: "EXISTS",
+      relation: "country_ranks",
+      country: "poland_rank",
+      rank__lt: 1000,
     });
   });
 
   test("toQuery with >= produces gte lookup", () => {
     const filter = BUCKET_FILTERS["poland_rank"];
     expect(filter.toQuery(500, ">=")).toEqual({
-      op: "AND",
-      country_ranks__country: "poland_rank",
-      country_ranks__rank__gte: 500,
+      op: "EXISTS",
+      relation: "country_ranks",
+      country: "poland_rank",
+      rank__gte: 500,
     });
   });
 
   test("toQuery with > produces gt lookup", () => {
     const filter = BUCKET_FILTERS["poland_rank"];
     expect(filter.toQuery(500, ">")).toEqual({
-      op: "AND",
-      country_ranks__country: "poland_rank",
-      country_ranks__rank__gt: 500,
+      op: "EXISTS",
+      relation: "country_ranks",
+      country: "poland_rank",
+      rank__gt: 500,
     });
   });
 
   test("toQuery with no op defaults to lte", () => {
     const filter = BUCKET_FILTERS["poland_rank"];
     expect(filter.toQuery(1000)).toEqual({
-      op: "AND",
-      country_ranks__country: "poland_rank",
-      country_ranks__rank__lte: 1000,
+      op: "EXISTS",
+      relation: "country_ranks",
+      country: "poland_rank",
+      rank__lte: 1000,
     });
   });
 

--- a/server/reportmanager/views.py
+++ b/server/reportmanager/views.py
@@ -14,6 +14,7 @@ from django.core.exceptions import FieldError, SuspiciousOperation
 from django.db.models import (
     Avg,
     Case,
+    Exists,
     ExpressionWrapper,
     F,
     FloatField,
@@ -34,12 +35,12 @@ from django.views.generic import TemplateView
 from django.views.generic.edit import CreateView, DeleteView, UpdateView
 from django.views.generic.list import ListView
 from rest_framework import mixins, status, viewsets
-from rest_framework.views import APIView
 from rest_framework.authentication import SessionAuthentication, TokenAuthentication
 from rest_framework.decorators import action
 from rest_framework.exceptions import MethodNotAllowed, ValidationError
 from rest_framework.filters import BaseFilterBackend, OrderingFilter
 from rest_framework.response import Response
+from rest_framework.views import APIView
 
 from webcompat.models import Report
 
@@ -659,7 +660,7 @@ class JsonQueryFilterBackend(BaseFilterBackend):
         querystr = request.query_params.get("query", None)
         if querystr is not None:
             try:
-                _, queryobj = json_to_query(querystr)
+                _, queryobj = json_to_query(querystr, queryset.model)
             except (RuntimeError, TypeError) as e:
                 raise InvalidArgumentException(f"error in query: {e}")
             try:
@@ -1273,11 +1274,15 @@ class BugzillaTemplateViewSet(
 #         return Response(status=status.HTTP_200_OK)
 
 
-def json_to_query(json_str):
+def json_to_query(json_str, model=None):
     """
     This method converts JSON objects into trees of Django Q objects.
     It can be used to provide the user the ability to perform complex
     queries on the database using JSON as a query string.
+
+    `model` is the model the resulting query will be filtered against. It is
+    only required for the "EXISTS" operator, which resolves its `relation`
+    against this model; other operators ignore it.
 
     The decoded JSON may only contain objects. Each object must contain
     an "op" key that describes the operation of the object. This can either
@@ -1302,6 +1307,32 @@ def json_to_query(json_str):
     except ValueError as e:
         raise RuntimeError(f"Invalid JSON: {e}")
 
+    def get_exists_obj(obj: dict) -> Q:
+        """Compile an EXISTS object into a correlated Exists() subquery.
+
+        Shape: {"op": "EXISTS", "relation": "<reverse_accessor>", <lookup>: <val>}
+
+        All lookups must match a single related row. This is required for
+        multi-field conditions on a multi-valued relation (e.g. country_ranks,
+        matching both `country` and `rank`): a flat AND of two related lookups
+        lets each match a different row and is silently wrong under negation.
+        """
+        if model is None:
+            raise RuntimeError("EXISTS query object requires a target model")
+        relation = obj.get("relation")
+        if not relation:
+            raise RuntimeError("EXISTS query object requires a 'relation'")
+        try:
+            descriptor = getattr(model, relation)
+            related_model = descriptor.rel.related_model
+            fk_name = descriptor.rel.field.name
+        except AttributeError:
+            raise RuntimeError(f"Unknown relation '{relation}' in EXISTS query object")
+
+        lookups = {k: v for k, v in obj.items() if k not in ("op", "relation")}
+        subquery = related_model.objects.filter(**{fk_name: OuterRef("pk")}, **lookups)
+        return Q(Exists(subquery))
+
     def get_query_obj(obj, key=None):
         if obj is None or isinstance(obj, str | list | int | float):
             kwargs = {key: obj}
@@ -1319,6 +1350,9 @@ def json_to_query(json_str):
 
         op = obj["op"]
         objkeys = [value for value in obj if value != "op"]
+
+        if op == "EXISTS":
+            return get_exists_obj(obj)
 
         if op == "NOT" and len(objkeys) > 1:
             raise RuntimeError("Attempted to negate multiple objects at once")

--- a/tests/test_country_rank_query.py
+++ b/tests/test_country_rank_query.py
@@ -1,0 +1,86 @@
+"""Tests for the country-rank filter's query semantics."""
+
+import json
+
+import pytest
+from django.utils import timezone
+
+from reportmanager.models import Bucket, BucketCountryRank
+from reportmanager.views import json_to_query
+
+
+def mkbucket(desc):
+    return Bucket.objects.create(description=desc, signature="{}")
+
+
+def rank(bucket, country, r):
+    BucketCountryRank.objects.create(
+        bucket=bucket, country=country, rank=r, updated_at=timezone.now()
+    )
+
+
+def run(query_str):
+    _, q = json_to_query(query_str, Bucket)
+    return set(Bucket.objects.filter(q).values_list("description", flat=True))
+
+
+@pytest.fixture
+def rank_fixture(db):
+    bbc = mkbucket("www.bbc.co.uk")
+    rank(bbc, "uk_rank", 1000)
+    rank(bbc, "global_rank", 1000)
+
+    less_popular = mkbucket("less-popular.co.uk")
+    rank(less_popular, "uk_rank", 1000)
+    rank(less_popular, "global_rank", 50000)
+
+    example = mkbucket("example.co.uk")
+    rank(example, "uk_rank", 5000)
+    rank(example, "global_rank", 50000)
+
+
+# The compiled JSON that the frontend CountryRankBucketFilter.toQuery emits.
+def rank_clause(country, threshold):
+    return {
+        "op": "EXISTS",
+        "relation": "country_ranks",
+        "country": country,
+        "rank__lte": threshold,
+    }
+
+
+@pytest.mark.django_db
+def test_single_rank_filter(rank_fixture):
+    """uk_rank:<=1000"""
+    got = run(json.dumps(rank_clause("uk_rank", 1000)))
+    assert got == {"www.bbc.co.uk", "less-popular.co.uk"}
+
+
+@pytest.mark.django_db
+def test_uk_but_not_global(rank_fixture):
+    """uk_rank:<=1000 AND NOT global_rank:<=1000"""
+    query = json.dumps(
+        {
+            "op": "AND",
+            "0": rank_clause("uk_rank", 1000),
+            "1": {"op": "NOT", "0": rank_clause("global_rank", 1000)},
+        }
+    )
+    got = run(query)
+    # less-popular.co.uk qualifies (global rank 50000, outside the top 1000);
+    # www.bbc.co.uk is excluded because it is in the global top 1000.
+    assert got == {"less-popular.co.uk"}
+
+
+@pytest.mark.django_db
+def test_uk_and_global(rank_fixture):
+    """uk_rank:<=1000 AND global_rank:<=1000"""
+    query = json.dumps(
+        {
+            "op": "AND",
+            "0": rank_clause("uk_rank", 1000),
+            "1": rank_clause("global_rank", 1000),
+        }
+    )
+    got = run(query)
+    assert got == {"www.bbc.co.uk"}


### PR DESCRIPTION
We've noticed in https://github.com/MozillaSecurity/WebCompatManager/pull/247 that queries like `uk_rank:<=1000 AND NOT global_rank:<=1000` does not exclude buckets with `global_rank<=1000`, so this PR adds support for that. 